### PR TITLE
Events page new layout

### DIFF
--- a/src/app/[locale]/events/(components)/EventsPage.tsx
+++ b/src/app/[locale]/events/(components)/EventsPage.tsx
@@ -46,6 +46,17 @@ export interface Props extends AutoProps {
   readonly mode: "UPCOMING_EVENTS" | "PAST_EVENTS";
 }
 
+const getEventFilter = (mode: "UPCOMING_EVENTS" | "PAST_EVENTS") => {
+  if (mode === "UPCOMING_EVENTS") {
+    return `start_date_ts > ${getUnixTime(
+      startOfDay(new Date())
+    )} OR end_date_ts > ${getUnixTime(startOfDay(new Date()))}`;
+  }
+  return `start_date_ts < ${getUnixTime(
+    startOfDay(new Date("April 1, 2023"))
+  )} AND end_date_ts < ${getUnixTime(startOfDay(new Date("April 1, 2023")))}`;
+};
+
 export function EventsPage({ params, env, mode }: Props): JSX.Element | null {
   const searchClient = useMemo(() => {
     return algoliasearch(env.ALGOLIA_APP_ID, env.ALGOLIA_SEARCH_API_KEY);
@@ -64,11 +75,7 @@ export function EventsPage({ params, env, mode }: Props): JSX.Element | null {
         <Configure
           hitsPerPage={40}
           facetsRefinements={{ locale: [params.locale] }}
-          filters={
-            mode === "UPCOMING_EVENTS"
-              ? `start_date_ts > ${getUnixTime(startOfDay(new Date()))}`
-              : `start_date_ts < ${getUnixTime(startOfDay(new Date()))}`
-          }
+          filters={getEventFilter(mode)}
         />
 
         <PageLayout


### PR DESCRIPTION
Notion link: https://www.notion.so/yuki-labs/Events-Update-layout-of-event-lists-c3563ef3644e426ebfd182d1b07f4f61

### Changes
1. Modified date filtering logic as per new requirements 
<img width="745" alt="Screen Shot 2023-04-13 at 01 51 04" src="https://user-images.githubusercontent.com/126797224/231582019-7c2a8a39-2eca-447b-a9f2-a249cc658ee6.png">

2. Grouped events by month and added `MM YYYY` subheader
<img width="749" alt="Screen Shot 2023-04-13 at 01 52 49" src="https://user-images.githubusercontent.com/126797224/231582404-4f807cec-c9f2-4294-b8d7-a10eef14c27f.png">

### Manual tests 

To test that new filter logic is working correctly, I used `April 22, 2023` as current date
 
<img width="421" alt="Screen Shot 2023-04-13 at 01 46 57" src="https://user-images.githubusercontent.com/126797224/231583122-53786519-b721-4e2b-af9b-44f0b17f3bf2.png">

#### Results before changes (read note below)

> **_NOTE:_**  Event for April 21-23 is shown in past events for April 22

<img width="988" alt="Screen Shot 2023-04-13 at 01 45 43" src="https://user-images.githubusercontent.com/126797224/231583403-4441c86e-11b1-41f6-a519-7494caeb0822.png">
<img width="1016" alt="Screen Shot 2023-04-13 at 01 46 13" src="https://user-images.githubusercontent.com/126797224/231583400-92136b77-6d54-4fbc-bfe0-9fc0b39b9ffd.png">

#### Results after the changes (read note below)

> **_NOTE:_**  Since current date is April 22, event for April 21-23 is shown in upcoming events instead of past events

<img width="1050" alt="Screen Shot 2023-04-13 at 01 48 50" src="https://user-images.githubusercontent.com/126797224/231583395-60d0ec58-51c4-4116-a566-152b18d1bb8b.png">
<img width="1087" alt="Screen Shot 2023-04-13 at 01 49 08" src="https://user-images.githubusercontent.com/126797224/231583359-ceb4f476-7502-4506-9592-eb76b0dabb45.png">