### PR TITLE
Add home link to all breadcrumbs

### DIFF
--- a/src/app/[locale]/[...slug]/page.tsx
+++ b/src/app/[locale]/[...slug]/page.tsx
@@ -24,7 +24,7 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
   try {
     const data = await getPageBySlug(
       props.params.slug.join("/"),
-      props.params.locale,
+      props.params.locale
     );
 
     return {
@@ -86,6 +86,14 @@ Props): JSX.Element {
               data.breadcrumbs_data &&
               data.breadcrumbs_data.length > 0 ? (
                 <Breadcrumb separator="/">
+                  <BreadcrumbItem>
+                    <BreadcrumbLink
+                      fontSize="sm"
+                      href={`/${data.breadcrumbs_data[0].locale}`}
+                    >
+                      Home
+                    </BreadcrumbLink>
+                  </BreadcrumbItem>
                   <BreadcrumbItem>
                     <BreadcrumbLink
                       fontSize="sm"

--- a/src/app/[locale]/events/(components)/EventsPage.tsx
+++ b/src/app/[locale]/events/(components)/EventsPage.tsx
@@ -16,7 +16,7 @@ import algoliasearch from "src/libs/algoliasearch/lite";
 import {
   InstantSearch,
   Configure,
-  useInfiniteHits
+  useInfiniteHits,
 } from "src/libs/react-instantsearch-hooks-web";
 import { useRefinementList } from "react-instantsearch-hooks";
 import { PageLayout } from "@ui/Layout/PageLayout";
@@ -81,6 +81,16 @@ export function EventsPage({ params, env, mode }: Props): JSX.Element | null {
           sectionHeaderDescription="Find Starknet events, online or around the world."
           breadcrumbs={
             <Breadcrumb separator="/">
+              <BreadcrumbItem>
+                <BreadcrumbLink
+                  as={Link}
+                  href={`/${params.locale}`}
+                  fontSize="sm"
+                  noOfLines={1}
+                >
+                  Home
+                </BreadcrumbLink>
+              </BreadcrumbItem>
               <BreadcrumbItem>
                 <BreadcrumbLink
                   as={Link}

--- a/src/app/[locale]/jobs/(components)/JobsPage.tsx
+++ b/src/app/[locale]/jobs/(components)/JobsPage.tsx
@@ -63,6 +63,16 @@ export function JobsPage({ params, env }: Props): JSX.Element | null {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   as={Link}
+                  href={`/${params.locale}`}
+                  fontSize="sm"
+                  noOfLines={1}
+                >
+                  Home
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbItem>
+                <BreadcrumbLink
+                  as={Link}
                   href={`/${params.locale}/community`}
                   fontSize="sm"
                   noOfLines={1}

--- a/src/app/[locale]/posts/(components)/PostsPage.tsx
+++ b/src/app/[locale]/posts/(components)/PostsPage.tsx
@@ -48,6 +48,7 @@ export function PostsPage({
   categories,
   topics,
 }: Props): JSX.Element | null {
+  console.log("topics", topics);
   const searchClient = useMemo(() => {
     return algoliasearch(env.ALGOLIA_APP_ID, env.ALGOLIA_SEARCH_API_KEY);
   }, [env.ALGOLIA_APP_ID, env.ALGOLIA_SEARCH_API_KEY]);
@@ -69,7 +70,7 @@ export function PostsPage({
               // topic: searchParams.get("topic")?.split(",") ?? [],
               category: category != null ? [category.id] : [],
             }),
-            [category, params.locale],
+            [category, params.locale]
           )}
         />
         <Container maxW="container.xl" mb={4}>
@@ -82,6 +83,16 @@ export function PostsPage({
               <BreadcrumbItem>
                 <BreadcrumbLink
                   as={Link}
+                  href={`/${params.locale}`}
+                  fontSize="sm"
+                  noOfLines={1}
+                >
+                  Home
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbItem>
+                <BreadcrumbLink
+                  as={Link}
                   href={`/${params.locale}/community`}
                   fontSize="sm"
                   noOfLines={1}
@@ -90,7 +101,7 @@ export function PostsPage({
                 </BreadcrumbLink>
               </BreadcrumbItem>
 
-              <BreadcrumbItem isCurrentPage fontSize='sm'>
+              <BreadcrumbItem isCurrentPage fontSize="sm">
                 <BreadcrumbLink fontSize="sm">Blog</BreadcrumbLink>
               </BreadcrumbItem>
             </Breadcrumb>

--- a/src/app/[locale]/posts/[category]/[slug]/page.tsx
+++ b/src/app/[locale]/posts/[category]/[slug]/page.tsx
@@ -112,6 +112,16 @@ export default async function Page({
             <BreadcrumbItem>
               <BreadcrumbLink
                 as={Link}
+                href={`/${locale}`}
+                fontSize="sm"
+                noOfLines={1}
+              >
+                Home
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbItem>
+              <BreadcrumbLink
+                as={Link}
                 href={`/${locale}/posts`}
                 fontSize="sm"
                 noOfLines={1}

--- a/src/app/[locale]/tutorials/(components)/TutorialsPage.tsx
+++ b/src/app/[locale]/tutorials/(components)/TutorialsPage.tsx
@@ -66,6 +66,16 @@ export function TutorialsPage({ params, env }: Props): JSX.Element | null {
               <BreadcrumbItem>
                 <BreadcrumbLink
                   as={Link}
+                  href={`/${params.locale}`}
+                  fontSize="sm"
+                  noOfLines={1}
+                >
+                  Home
+                </BreadcrumbLink>
+              </BreadcrumbItem>
+              <BreadcrumbItem>
+                <BreadcrumbLink
+                  as={Link}
                   href={`/${params.locale}/developers`}
                   fontSize="sm"
                   noOfLines={1}


### PR DESCRIPTION
Task details: https://www.notion.so/yuki-labs/breadcrumbs-add-home-to-the-start-of-each-link-3bd3626c331340068436153d57e23a1a

Affected pages: 

1. [locale]/[...slug] pages (e.g. [Community governance](https://starknet-website-git-add-home-to-breadcrumb-yuki-labs.vercel.app/en/community/governance) and [Tools and resources](https://starknet-website-git-add-home-to-breadcrumb-yuki-labs.vercel.app/en/developers/tools-and-resources))
2. [Events page](https://starknet-website-git-add-home-to-breadcrumb-yuki-labs.vercel.app/en/events)
3. [Jobs page](https://starknet-website-git-add-home-to-breadcrumb-yuki-labs.vercel.app/en/jobs)
4. [All posts page](https://starknet-website-git-add-home-to-breadcrumb-yuki-labs.vercel.app/en/posts)
5. [Category posts pages](https://starknet-website-git-add-home-to-breadcrumb-yuki-labs.vercel.app/en/posts/engineering/what-are-storage-proofs-and-how-can-they-improve-oracles)
6. [Tutorials page](https://starknet-website-git-add-home-to-breadcrumb-yuki-labs.vercel.app/en/tutorials)