### PR TITLE
Fix empty topics in posts page

### DIFF
--- a/src/app/[locale]/posts/(components)/PostsPage.tsx
+++ b/src/app/[locale]/posts/(components)/PostsPage.tsx
@@ -108,7 +108,12 @@ export function PostsPage({
           }
           leftAside={
             <Box minH="xs" display={{ base: "none", lg: "block" }}>
-              <Heading mt="-24px" color="heading-navy-fg" variant="h4">
+              <Heading
+                mt="-24px"
+                color="heading-navy-fg"
+                variant="h4"
+                mb="1rem"
+              >
                 Topics
               </Heading>
               <CustomTopics topics={topics} />
@@ -139,9 +144,20 @@ function CustomTopics({ topics }: Pick<Props, "topics">) {
     sortBy: ["count:desc"],
   });
 
+  const topicsDict = useMemo(() => {
+    return topics.reduce((acc, topic) => {
+      acc[topic.id] = topic;
+      return acc;
+    }, {} as Record<string, Topic>);
+  }, [topics]);
+
+  const validTopics = useMemo(() => {
+    return items.filter((topic) => topicsDict[topic.value] != null);
+  }, [topicsDict, items]);
+
   return (
     <Box display="flex" flexWrap="wrap" gap="8px" columnGap="4px" width="100%">
-      {items.map((topic, i) => (
+      {validTopics.map((topic, i) => (
         <Button
           size="sm"
           px="8px"
@@ -167,7 +183,7 @@ function CustomTopics({ topics }: Pick<Props, "topics">) {
           }}
           key={i}
         >
-          {topics.find((a) => a.id === topic.value)?.name}
+          {topicsDict[topic.value].name}
         </Button>
       ))}
     </Box>


### PR DESCRIPTION
Task details: https://www.notion.so/Fix-blog-topics-empty-boxes-66a210b10e6640928b679df75ecb1e2d

Changes: 
- Remove empty topic boxes
- Add margin bottom to topic title

Before changes: 
<img width="536" alt="Screen Shot 2023-04-25 at 17 04 36" src="https://user-images.githubusercontent.com/126797224/234270764-34613e62-3a3b-4925-bce8-54da28541471.png">

After changes:
<img width="588" alt="Screen Shot 2023-04-25 at 17 05 12" src="https://user-images.githubusercontent.com/126797224/234270878-c94ad0f2-4d03-4faf-bd6b-3800305e804e.png">
