### PR TITLE
Events: update filters

### DIFF
--- a/_data/events/consensus-by-coindesk.yml
+++ b/_data/events/consensus-by-coindesk.yml
@@ -7,7 +7,7 @@ url: https://consensus.coindesk.com/
 start_date: 2023-04-26T06:00:41.962Z
 end_date: 2023-04-28T16:00:41.967Z
 image: /assets/wy9q_hj8_400x400.png
-location: usa
+location: north_america
 tags:
   - crypto
   - blockchain

--- a/_data/events/duke-blockchain-conference.yml
+++ b/_data/events/duke-blockchain-conference.yml
@@ -5,7 +5,7 @@ url: https://www.dukeweb3conference.com/
 start_date: 2023-04-21T06:00:46.333Z
 end_date: 2023-04-23T15:30:46.339Z
 image: /assets/63d704b2883e452ca71cfe5f_fuqua-blockchain-club-coin-logo-copy-min-1.svg
-location: usa
+location: north_america
 city: Durham
 country: "North Carolina "
 tags:

--- a/_data/events/eth-austin.yml
+++ b/_data/events/eth-austin.yml
@@ -6,7 +6,7 @@ url: https://2023.ethaustin.org/
 start_date: 2023-04-25T06:30:28.463Z
 end_date: 2023-04-25T15:00:28.470Z
 image: /assets/eth-austin.png
-location: usa
+location: north_america
 tags:
   - crypto
   - blockchain

--- a/_data/events/hbc2023.yml
+++ b/_data/events/hbc2023.yml
@@ -5,7 +5,7 @@ url: https://www.harvardblockchain.xyz/
 start_date: 2023-03-30T09:10:27.037Z
 end_date: 2023-03-30T09:10:27.043Z
 image: /assets/hbc23-2x.png
-location: usa
+location: north_america
 tags:
   - crypto
   - blockchain

--- a/_data/events/mit-bitcoin-expo.yml
+++ b/_data/events/mit-bitcoin-expo.yml
@@ -8,7 +8,7 @@ url: http://mitbitcoinexpo.org/
 start_date: 2023-04-22T06:00:31.815Z
 end_date: 2023-04-23T13:13:00.000Z
 image: /assets/btcmit.jpg
-location: usa
+location: north_america
 city: Cambridge
 country: Massachusetts
 tags:

--- a/_data/events/starkboston-meet-up.yml
+++ b/_data/events/starkboston-meet-up.yml
@@ -6,7 +6,7 @@ url: https://www.eventbrite.com/e/starkboston-meet-up-tickets-622187929847?aff=e
 start_date: 2023-04-23T15:00:32.543Z
 end_date: 2023-04-23T18:00:32.550Z
 image: /assets/https-cdn.evbuc.com-images-498161299-1017171333403-1-original.20230421-161754.jpeg
-location: usa
+location: north_america
 city: "Boston "
 country: Massachusetts
 tags:

--- a/_data/events/starknet-meetup-in-austin.yml
+++ b/_data/events/starknet-meetup-in-austin.yml
@@ -6,7 +6,7 @@ url: https://www.eventbrite.com/e/starknet-meetup-in-austin-tickets-617024576117
 start_date: 2023-04-25T15:00:00.254Z
 end_date: 2023-04-25T18:00:00.264Z
 image: /assets/starknet-austin-meetup.png
-location: usa
+location: north_america
 city: Austin
 country: Texas
 tags:

--- a/src/app/[locale]/events/(components)/EventsPage.tsx
+++ b/src/app/[locale]/events/(components)/EventsPage.tsx
@@ -172,7 +172,7 @@ function CustomLocation() {
       <Heading variant="h6" mb={4}>
         Location
       </Heading>
-      <VStack dir="column" alignItems="stretch">
+      <Flex direction="column" gap="8px">
         {items.map((item, i) => (
           <Button
             justifyContent="flex-start"
@@ -180,11 +180,12 @@ function CustomLocation() {
             variant={item.isRefined ? "filterActive" : "filter"}
             onClick={() => refine(item.value)}
             key={i}
+            style={{ order: item.value === "online_remote" ? -1 : 0 }}
           >
             {eventsLocationsLabels[item.value] || titleCase(item.label)}
           </Button>
         ))}
-      </VStack>
+      </Flex>
     </Box>
   );
 }

--- a/src/app/[locale]/events/(components)/EventsPage.tsx
+++ b/src/app/[locale]/events/(components)/EventsPage.tsx
@@ -28,6 +28,10 @@ import { Event } from "@starknet-io/cms-data/src/events";
 import type { BaseHit } from "instantsearch.js";
 import Link from "next/link";
 import { getUnixTime, startOfDay } from "date-fns";
+import {
+  eventsTypesLabels,
+  eventsLocationsLabels,
+} from "workspaces/cms-config/src/collections/events";
 
 export interface AutoProps {
   readonly params: {
@@ -177,7 +181,7 @@ function CustomLocation() {
             onClick={() => refine(item.value)}
             key={i}
           >
-            {titleCase(item.label)}
+            {eventsLocationsLabels[item.value] || titleCase(item.label)}
           </Button>
         ))}
       </VStack>
@@ -205,7 +209,7 @@ function CustomType() {
             onClick={() => refine(item.value)}
             key={i}
           >
-            {titleCase(item.label)}
+            {eventsTypesLabels[item.value] || titleCase(item.label)}
           </Button>
         ))}
       </VStack>

--- a/workspaces/cms-config/src/collections/events.ts
+++ b/workspaces/cms-config/src/collections/events.ts
@@ -1,5 +1,69 @@
 import type { CmsConfig } from "netlify-cms-core";
 
+export const eventsLocations = [
+  {
+    label: "Online / Remote",
+    value: "online_remote",
+  },
+  {
+    label: "USA",
+    value: "usa",
+  },
+  {
+    label: "Africa",
+    value: "africa",
+  },
+  {
+    label: "Asia",
+    value: "asia",
+  },
+  {
+    label: "Australia / Oceania",
+    value: "australia_oceania",
+  },
+  {
+    label: "Europe",
+    value: "europe",
+  },
+  {
+    label: "North America",
+    value: "north_america",
+  },
+  {
+    label: "South America",
+    value: "south_america",
+  },
+];
+
+export const eventsLocationsLabels = eventsLocations.reduce((acc, curr) => {
+  acc[curr.value] = curr.label;
+  return acc;
+}, {} as Record<string, string>);
+
+export const eventsTypes = [
+  {
+    label: "Community Event",
+    value: "community_event",
+  },
+  {
+    label: "Conference",
+    value: "conference",
+  },
+  {
+    label: "Hackathon",
+    value: "hackathon",
+  },
+  {
+    label: "Meetup",
+    value: "meetup",
+  },
+];
+
+export const eventsTypesLabels = eventsTypes.reduce((acc, curr) => {
+  acc[curr.value] = curr.label;
+  return acc;
+}, {} as Record<string, string>);
+
 export const eventsCollectionConfig = {
   name: "events",
   label: "Events",
@@ -14,24 +78,7 @@ export const eventsCollectionConfig = {
       name: "type",
       label: "Type",
       widget: "select",
-      options: [
-        {
-          label: "Community Event",
-          value: "community_event",
-        },
-        {
-          label: "Conference",
-          value: "conference",
-        },
-        {
-          label: "Hackathon",
-          value: "hackathon",
-        },
-        {
-          label: "Meetup",
-          value: "meetup",
-        },
-      ],
+      options: eventsTypes,
     },
     {
       name: "name",
@@ -68,40 +115,7 @@ export const eventsCollectionConfig = {
       name: "location",
       label: "Location",
       widget: "select",
-      options: [
-        {
-          label: "Online / Remote",
-          value: "online_remote",
-        },
-        {
-          label: "USA",
-          value: "usa",
-        },
-        {
-          label: "Africa",
-          value: "africa",
-        },
-        {
-          label: "Asia",
-          value: "asia",
-        },
-        {
-          label: "Australia / Oceania",
-          value: "australia_oceania",
-        },
-        {
-          label: "Europe",
-          value: "europe",
-        },
-        {
-          label: "North America",
-          value: "north_america",
-        },
-        {
-          label: "South America",
-          value: "south_america",
-        },
-      ],
+      options: eventsLocations,
     },
     {
       name: "city",

--- a/workspaces/cms-config/src/collections/events.ts
+++ b/workspaces/cms-config/src/collections/events.ts
@@ -6,10 +6,6 @@ export const eventsLocations = [
     value: "online_remote",
   },
   {
-    label: "USA",
-    value: "usa",
-  },
-  {
     label: "Africa",
     value: "africa",
   },


### PR DESCRIPTION
Task details: https://www.notion.so/yuki-labs/Events-Update-filters-ec7f11dc852a4c27a2bdcb7c3942780b

Preview: https://starknet-website-git-fix-events-labels-yuki-labs.vercel.app/en/events

Changes:
- Use the location labels provided in cms config instead of capitalized label (e.g. `Online / Remote` instead of `Online Remote` etc)
- Change USA location events to North America and remove USA
- Move `Online / Remote` to top
- Update algolia index

Before:

<img width="100%" alt="Screen Shot 2023-04-26 at 16 46 16" src="https://user-images.githubusercontent.com/126797224/234565388-3fb611c4-4313-4bd8-a01d-5ef0c4203a00.png">

After:

<img width="100%" alt="Screen Shot 2023-04-26 at 16 44 33" src="https://user-images.githubusercontent.com/126797224/234564974-5cfa6013-6f4b-499c-8915-f044393f0b1c.png">
