### PR TITLE
Events: Keep/remove events when over

### DIFF
--- a/_data/events/btc-prague.yml
+++ b/_data/events/btc-prague.yml
@@ -1,10 +1,11 @@
 type: conference
 name: BTC Prague
 description: BTC Prague aims to connect bitcoin communities and grow bitcoin
-  adoption by welcoming 10,000 visitors from around the world. 
+  adoption by welcoming 10,000 visitors from around the world.
 url: https://www.btcprague.com/#
 start_date: 2023-06-08T13:39:35.920Z
 end_date: 2023-06-10T13:39:35.925Z
+show_in_past_events: true
 image: /assets/btc-prague-2023.jpeg
 location: europe
 city: Prague

--- a/_data/events/buidl-asia-2023.yml
+++ b/_data/events/buidl-asia-2023.yml
@@ -6,6 +6,7 @@ description: BUIDL Asia is a technical conference that strives to share the
 url: https://www.buidl.asia/
 start_date: 2023-06-06T13:01:25.542Z
 end_date: 2023-06-07T13:01:25.546Z
+show_in_past_events: true
 image: /assets/etf5ubnt_400x400.jpg
 location: asia
 tags:

--- a/_data/events/cairo-1-and-starknet-roadmap.yml
+++ b/_data/events/cairo-1-and-starknet-roadmap.yml
@@ -5,6 +5,7 @@ description: Starknet, Cairo 1 and everything about Starknet's roadmap, as well
 url: https://www.meetup.com/starknet-melbourne/events/291944115/
 start_date: 2023-03-30T07:50:35.618Z
 end_date: ""
+show_in_past_events: true
 image: /assets/starknet-meetups.jpg
 location: australia_oceania
 city: Melbourne

--- a/_data/events/club3-meetup-zk-rollups.yml
+++ b/_data/events/club3-meetup-zk-rollups.yml
@@ -5,6 +5,7 @@ description: Take a tech deep dive into the most relevant zk Rollups that have
 url: https://www.meetup.com/fr-FR/club-3/events/ndqsssyfcgbgb/
 start_date: 2023-04-12T15:00:52.749Z
 end_date: 2023-04-12T17:00:52.757Z
+show_in_past_events: true
 image: /assets/600_511863402.webp
 location: europe
 city: "Zurich "

--- a/_data/events/consensus-by-coindesk.yml
+++ b/_data/events/consensus-by-coindesk.yml
@@ -6,6 +6,7 @@ description: Consensus is the world's largest, longest-running and most
 url: https://consensus.coindesk.com/
 start_date: 2023-04-26T06:00:41.962Z
 end_date: 2023-04-28T16:00:41.967Z
+show_in_past_events: true
 image: /assets/wy9q_hj8_400x400.png
 location: north_america
 tags:

--- a/_data/events/cscml-2023.yml
+++ b/_data/events/cscml-2023.yml
@@ -8,6 +8,7 @@ description: The 7th International Symposium on Cyber Security, Cryptology and
 url: https://www.cscml.org/
 start_date: 2023-06-23T15:02:59.411Z
 end_date: 2023-06-30T15:02:59.418Z
+show_in_past_events: true
 image: /assets/the-international-symposium-on-cyber-security-cryptology-and-machine-learning-cscml-.webp
 location: online_remote
 tags:

--- a/_data/events/duke-blockchain-conference.yml
+++ b/_data/events/duke-blockchain-conference.yml
@@ -4,6 +4,7 @@ description: The 2023 edition of the Duke University’s Web3 Conference!
 url: https://www.dukeweb3conference.com/
 start_date: 2023-04-21T06:00:46.333Z
 end_date: 2023-04-23T15:30:46.339Z
+show_in_past_events: true
 image: /assets/63d704b2883e452ca71cfe5f_fuqua-blockchain-club-coin-logo-copy-min-1.svg
 location: north_america
 city: Durham

--- a/_data/events/eth-austin.yml
+++ b/_data/events/eth-austin.yml
@@ -5,6 +5,7 @@ description: ETH Austin is a gathering of ETH folks from the Southwest. The goal
 url: https://2023.ethaustin.org/
 start_date: 2023-04-25T06:30:28.463Z
 end_date: 2023-04-25T15:00:28.470Z
+show_in_past_events: true
 image: /assets/eth-austin.png
 location: north_america
 tags:

--- a/_data/events/ethcc-ethereum-community-conference.yml
+++ b/_data/events/ethcc-ethereum-community-conference.yml
@@ -6,6 +6,7 @@ description: The Ethereum Community Conference (EthCC) is the largest annual
 url: https://www.ethcc.io/
 start_date: 2023-07-17T13:45:09.143Z
 end_date: 2023-07-20T13:45:09.148Z
+show_in_past_events: true
 image: /assets/ethcc-ethereum-community-conference.jpeg
 location: europe
 tags:

--- a/_data/events/ethglobal-paris.yml
+++ b/_data/events/ethglobal-paris.yml
@@ -4,6 +4,7 @@ description: "Join the ETHGlobal Hackathon in Paris! Bring your laptop and let's
 url: https://ethglobal.com/events/paris2023
 start_date: 2023-07-21T06:00:12.709Z
 end_date: 2023-07-23T15:00:12.717Z
+show_in_past_events: true
 image: /assets/1-fherdrczy-d9w787cboy8q.png
 location: europe
 city: "Paris "

--- a/_data/events/ethprague.yml
+++ b/_data/events/ethprague.yml
@@ -7,6 +7,7 @@ description: The event focuses on the future of Ethereum and potential concepts
 url: https://ethprague.com/
 start_date: 2023-06-09T14:27:09.182Z
 end_date: 2023-06-11T14:27:09.188Z
+show_in_past_events: true
 image: /assets/ethprague.jpeg
 location: europe
 tags:

--- a/_data/events/hacksummit.yml
+++ b/_data/events/hacksummit.yml
@@ -5,6 +5,7 @@ description: A Virtual Conference for Blockchain Developers Featuring the
 url: http://2023.hacksummit.org/
 start_date: 2023-03-31T09:27:04.521Z
 end_date: 2023-04-02T09:27:04.535Z
+show_in_past_events: true
 image: /assets/hacksummit.jpg
 location: online_remote
 tags:

--- a/_data/events/hbc2023.yml
+++ b/_data/events/hbc2023.yml
@@ -4,6 +4,7 @@ description: A top student-run blockchain innovation hub.
 url: https://www.harvardblockchain.xyz/
 start_date: 2023-03-30T09:10:27.037Z
 end_date: 2023-03-30T09:10:27.043Z
+show_in_past_events: true
 image: /assets/hbc23-2x.png
 location: north_america
 tags:

--- a/_data/events/meet-starkware-with-manmit-singh.yml
+++ b/_data/events/meet-starkware-with-manmit-singh.yml
@@ -5,6 +5,7 @@ description: Networking, Drinks, and Meet Starkware with Manmit Singh  Meet
 url: https://www.meetup.com/open-future-forum/events/293068172/?isFirstPublish=true
 start_date: 2023-05-02T15:30:07.439Z
 end_date: 2023-05-02T17:30:07.448Z
+show_in_past_events: true
 image: /assets/600_512280080.webp
 location: north_america
 city: "Paolo Alto "

--- a/_data/events/mit-bitcoin-expo.yml
+++ b/_data/events/mit-bitcoin-expo.yml
@@ -7,6 +7,7 @@ description: MIT Bitcoin Expo is the longest-running collegiate conference about
 url: http://mitbitcoinexpo.org/
 start_date: 2023-04-22T06:00:31.815Z
 end_date: 2023-04-23T13:13:00.000Z
+show_in_past_events: true
 image: /assets/btcmit.jpg
 location: north_america
 city: Cambridge

--- a/_data/events/paris-blockchain-week-summit.yml
+++ b/_data/events/paris-blockchain-week-summit.yml
@@ -6,6 +6,7 @@ description: The Paris Blockchain Week Summit is a two-day event that explores
 url: https://www.parisblockchainweek.com/summit#speakers
 start_date: 2023-03-20T09:50:05.569Z
 end_date: 2023-03-24T09:50:05.575Z
+show_in_past_events: true
 image: /assets/paris_blockchain_week-summit-2x.png
 location: europe
 tags:

--- a/_data/events/prague-blockchain-week.yml
+++ b/_data/events/prague-blockchain-week.yml
@@ -7,6 +7,7 @@ description: A decentralized gathering of all people interested in
 url: https://prgblockweek.com/
 start_date: 2023-06-02T13:14:32.305Z
 end_date: 2023-06-11T13:14:32.310Z
+show_in_past_events: true
 image: /assets/prague-blockchain-week-2023.jpeg
 location: europe
 tags:

--- a/_data/events/prague-defi-summit-2023.yml
+++ b/_data/events/prague-defi-summit-2023.yml
@@ -5,6 +5,7 @@ description: Prague DeFi Summit has been designed around community collaboration
 url: https://praguedefisummit.com/
 start_date: 2023-06-08T14:14:42.855Z
 end_date: 2023-06-09T14:14:42.860Z
+show_in_past_events: true
 image: /assets/prague-defi-summit-2023.jpeg
 location: europe
 tags:

--- a/_data/events/starkboston-meet-up.yml
+++ b/_data/events/starkboston-meet-up.yml
@@ -5,6 +5,7 @@ description: Join us for an evening of exciting discussions and networking with
 url: https://www.eventbrite.com/e/starkboston-meet-up-tickets-622187929847?aff=estw&utm-campaign=social&utm-content=attendeeshare&utm-medium=discovery&utm-source=tw&utm-term=checkoutwidget
 start_date: 2023-04-23T15:00:32.543Z
 end_date: 2023-04-23T18:00:32.550Z
+show_in_past_events: true
 image: /assets/https-cdn.evbuc.com-images-498161299-1017171333403-1-original.20230421-161754.jpeg
 location: north_america
 city: "Boston "

--- a/_data/events/starknet-amsterdam-1.yml
+++ b/_data/events/starknet-amsterdam-1.yml
@@ -17,6 +17,7 @@ description: Calling the Starknet community of Amsterdam!  🎺 Starknet is
 url: https://www.meetup.com/starknet-amsterdam/events/293197940/?utm_medium=referral&utm_campaign=share-btn_savedevents_share_modal&utm_source=link
 start_date: 2023-05-18T15:00:38.980Z
 end_date: 2023-05-18T06:00:38.987Z
+show_in_past_events: true
 image: /assets/600_512437958.jpeg
 location: europe
 city: Amsterdam

--- a/_data/events/starknet-asia-tokyo-workshop.yml
+++ b/_data/events/starknet-asia-tokyo-workshop.yml
@@ -5,6 +5,7 @@ description: Stark Tokyo Cairo 1 workshop featuring our very own Ori Ziv. This
 url: https://www.eventbrite.com/e/starknet-asia-tokyo-workshop--tickets-607083030687
 start_date: 2023-04-14T09:00:52.805Z
 end_date: 2023-04-14T13:00:52.813Z
+show_in_past_events: true
 image: /assets/https-cdn.evbuc.com-images-483692699-1067276682753-1-original.20230403-072708.webp
 location: asia
 tags:

--- a/_data/events/starknet-connect-india-bangalore-edition.yml
+++ b/_data/events/starknet-connect-india-bangalore-edition.yml
@@ -8,6 +8,7 @@ description: "​For the first time in South India, Starknet in Collaboration wi
 url: https://lu.ma/StarknetConnect_Blr
 start_date: 2023-04-30T14:00:54.576Z
 end_date: 2023-04-30T17:00:54.581Z
+show_in_past_events: true
 image: /assets/screenshot-2023-04-27-at-14.36.59.png
 location: asia
 city: Bangalore

--- a/_data/events/starknet-connect-india-pune-edition.yml
+++ b/_data/events/starknet-connect-india-pune-edition.yml
@@ -9,6 +9,7 @@ description: "​For the first time in South India, Starknet in Collaboration wi
 url: https://lu.ma/StarknetConnect_Pune
 start_date: 2023-04-29T09:00:20.588Z
 end_date: 2023-04-29T12:00:20.595Z
+show_in_past_events: true
 image: /assets/screenshot-2023-04-27-at-14.34.55.png
 location: asia
 city: Pune

--- a/_data/events/starknet-connect-pune-part-2.yml
+++ b/_data/events/starknet-connect-pune-part-2.yml
@@ -8,6 +8,7 @@ description: ​Starknet in Collaboration with The Phoenix Guild (TPG) is
 url: https://lu.ma/StarknetConnect_Pune2
 start_date: 2023-05-06T08:00:35.138Z
 end_date: 2023-05-06T11:00:35.144Z
+show_in_past_events: true
 image: /assets/image-04-05-2023-at-10.38.jpeg
 location: asia
 city: Pune

--- a/_data/events/starknet-london-meetup-3.yml
+++ b/_data/events/starknet-london-meetup-3.yml
@@ -6,6 +6,7 @@ description: The third Starknet London meetup - co-hosted by Argent and
 url: https://www.meetup.com/starknet-london/events/292993792?response=3&action=rsvp&utm_medium=email&utm_source=braze_canvas&utm_campaign=mmrk_alleng_event_announcement_prod_v7_en&utm_term=promo&utm_content=lp_meetup
 start_date: 2023-04-24T15:30:09.201Z
 end_date: 2023-04-24T18:30:09.209Z
+show_in_past_events: false
 image: /assets/600_511316115.webp
 location: europe
 city: "London "

--- a/_data/events/starknet-meetup-beijing.yml
+++ b/_data/events/starknet-meetup-beijing.yml
@@ -9,6 +9,7 @@ recap:
   isExternal: true
 start_date: 2023-04-09T07:00:50.843Z
 end_date: 2023-04-09T13:00:50.856Z
+show_in_past_events: true
 image: /assets/fs2a4dkauaejf-3.jpeg
 location: asia
 city: "Beijing "

--- a/_data/events/starknet-meetup-in-austin.yml
+++ b/_data/events/starknet-meetup-in-austin.yml
@@ -5,6 +5,7 @@ description: Join us for an evening dedicated to exploring Starknet's innovative
 url: https://www.eventbrite.com/e/starknet-meetup-in-austin-tickets-617024576117
 start_date: 2023-04-25T15:00:00.254Z
 end_date: 2023-04-25T18:00:00.264Z
+show_in_past_events: true
 image: /assets/starknet-austin-meetup.png
 location: north_america
 city: Austin

--- a/_data/events/starknet-meetup-zurich.yml
+++ b/_data/events/starknet-meetup-zurich.yml
@@ -5,6 +5,7 @@ description: Join us for an evening dedicated to exploring StarkWare's and
 url: https://www.eventbrite.com/e/starknet-meetup-in-zurich-tickets-606466867727
 start_date: 2023-04-13T15:00:57.301Z
 end_date: 2023-04-13T18:00:57.308Z
+show_in_past_events: true
 image: /assets/zurich-meetup-2-2-.jpg
 location: europe
 city: "Zurich "

--- a/_data/events/starknet-paris-meetup-8.yml
+++ b/_data/events/starknet-paris-meetup-8.yml
@@ -8,6 +8,7 @@ description: Nearly 300 of you registered for our last meetup at the Crowne
 url: https://www.meetup.com/fr-FR/starknet-paris/events/292808856/
 start_date: 2023-04-27T15:15:40.650Z
 end_date: 2023-04-27T19:00:40.659Z
+show_in_past_events: true
 image: /assets/600_509604259.webp
 location: europe
 city: "Paris "

--- a/_data/events/starknet-portugal-meetup-2-lisbon-edition.yml
+++ b/_data/events/starknet-portugal-meetup-2-lisbon-edition.yml
@@ -9,6 +9,7 @@ description: We are back again, this time in Lisbon! After the success of the
 url: https://www.meetup.com/starknet-portugal/events/293197894/
 start_date: 2023-05-09T15:30:42.070Z
 end_date: 2023-05-09T18:00:42.077Z
+show_in_past_events: true
 image: /assets/600_512438412.jpeg
 location: europe
 city: "Lisbon "

--- a/_data/events/starknet-prague-1.yml
+++ b/_data/events/starknet-prague-1.yml
@@ -6,6 +6,7 @@ description: Come meet the Czech StarkNet community, learn about what StarkNet
 url: https://www.meetup.com/starknet-prague/events/292507534/
 start_date: 2023-04-24T15:00:32.287Z
 end_date: 2023-04-24T18:00:32.295Z
+show_in_past_events: true
 image: /assets/event_511466424.webp
 location: europe
 city: "Prague "

--- a/_data/events/starkware-sessions-2023.yml
+++ b/_data/events/starkware-sessions-2023.yml
@@ -6,6 +6,7 @@ description: Bringing together the Ethereum community for a two-day event of
 url: https://starkwaresessions.co/
 start_date: 2023-02-05T00:00:00+00:00
 end_date: 2023-02-06T00:00:00+00:00
+show_in_past_events: true
 location: asia
 country: Israel
 image: /assets/logo_starkware_400x400.png

--- a/_data/events/talks-about-starknet.yml
+++ b/_data/events/talks-about-starknet.yml
@@ -5,6 +5,7 @@ description: Join us to learn about Ethereum's scalability solution from
 url: https://www.eventbrite.com.ar/e/charlas-sobre-starknet-tickets-612447977387
 start_date: 2023-04-14T15:30:02.533Z
 end_date: 2023-04-14T19:00:02.541Z
+show_in_past_events: true
 image: /assets/https-cdn.evbuc.com-images-488426269-245141212064-1-original.20230409-005838.jpeg
 location: south_america
 city: "Buenos Aires "

--- a/_data/events/the-satoshi-mystery-at-the-origins-of-bitcoin.yml
+++ b/_data/events/the-satoshi-mystery-at-the-origins-of-bitcoin.yml
@@ -7,6 +7,7 @@ description: Join Efrei Crypto Paris for a unique evening at Club de l'Etoile
 url: https://www.helloasso.com/associations/efrei-crypto-paris/evenements/cine-debat-le-mystere-de-satoshi-aux-origines-du-bitcoin
 start_date: 2023-04-21T16:30:17.505Z
 end_date: 2023-04-21T19:00:17.513Z
+show_in_past_events: true
 image: /assets/film_debate_marketing.png
 location: europe
 city: "Paris "

--- a/_data/events/waterloo-blockchain-olympihacks.yml
+++ b/_data/events/waterloo-blockchain-olympihacks.yml
@@ -6,6 +6,7 @@ description: "Join Waterloo Blockchain's Talent Pipeline for a Weekend Filled
 url: https://www.uwblockchain.ca/olympihacks
 start_date: 2023-05-19T06:00:17.155Z
 end_date: 2023-05-21T15:00:17.162Z
+show_in_past_events: true
 image: /assets/screenshot-2023-04-27-at-14.58.08.png
 location: north_america
 city: Waterloo

--- a/src/app/[locale]/(components)/MainSearch.tsx
+++ b/src/app/[locale]/(components)/MainSearch.tsx
@@ -186,8 +186,6 @@ export function MainSearch({ env, seo }: Props): JSX.Element | null {
     );
   }, []);
 
-  console.log("seo.title", seo.title);
-
   return (
     <Box position="relative">
       <Autocomplete<any>

--- a/src/app/[locale]/events/(components)/EventsPage.tsx
+++ b/src/app/[locale]/events/(components)/EventsPage.tsx
@@ -62,7 +62,7 @@ const getEventFilter = (mode: "UPCOMING_EVENTS" | "PAST_EVENTS") => {
       startOfDay(new Date())
     )} OR end_date_ts > ${getUnixTime(startOfDay(new Date()))}`;
   }
-  return `start_date_ts < ${getUnixTime(
+  return `NOT show_in_past_events:false AND start_date_ts < ${getUnixTime(
     startOfDay(new Date())
   )} AND end_date_ts < ${getUnixTime(startOfDay(new Date()))}`;
 };
@@ -282,16 +282,13 @@ function CustomHits({ isPastEvent }: { isPastEvent: boolean }) {
       let month = startDate.getMonth();
       let year = startDate.getFullYear();
       let key = `${year}-${month + 1}`;
-      if (isPastEvent && !hit.show_in_past_events) {
-        return;
-      }
       if (!hitsByMonthDict[key]) {
         hitsByMonthDict[key] = [];
       }
       hitsByMonthDict[key].push(hit);
     });
     return hitsByMonthDict;
-  }, [hits, isPastEvent]);
+  }, [hits]);
 
   return (
     <>

--- a/src/app/[locale]/events/(components)/EventsPage.tsx
+++ b/src/app/[locale]/events/(components)/EventsPage.tsx
@@ -282,13 +282,16 @@ function CustomHits({ isPastEvent }: { isPastEvent: boolean }) {
       let month = startDate.getMonth();
       let year = startDate.getFullYear();
       let key = `${year}-${month + 1}`;
+      if (isPastEvent && !hit.show_in_past_events) {
+        return;
+      }
       if (!hitsByMonthDict[key]) {
         hitsByMonthDict[key] = [];
       }
       hitsByMonthDict[key].push(hit);
     });
     return hitsByMonthDict;
-  }, [hits]);
+  }, [hits, isPastEvent]);
 
   return (
     <>

--- a/workspaces/cms-config/src/collections/events.ts
+++ b/workspaces/cms-config/src/collections/events.ts
@@ -135,6 +135,12 @@ export const eventsCollectionConfig = {
       required: false,
     },
     {
+      name: "show_in_past_events",
+      label: "Show in Past Events",
+      widget: "boolean",
+      default: true,
+    },
+    {
       name: "image",
       label: "Event Image",
       widget: "image",

--- a/workspaces/cms-config/src/collections/events.ts
+++ b/workspaces/cms-config/src/collections/events.ts
@@ -148,7 +148,7 @@ export const eventsCollectionConfig = {
     },
     {
       name: "show_in_past_events",
-      label: "Show in Past Events",
+      label: "Show in Past Events (after it ends)",
       widget: "boolean",
       default: true,
     },

--- a/workspaces/cms-config/src/collections/events.ts
+++ b/workspaces/cms-config/src/collections/events.ts
@@ -67,9 +67,21 @@ export const eventsCollectionConfig = {
   label_singular: "Event",
   folder: "_data/events",
   slug: "{{name}}",
-  summary: "{{name}}",
+  sortable_fields: ["name", "start_date", "end_date"],
+  summary:
+    "{{name}} [{{start_date | date('YYYY-MM-DD')}} - {{end_date | date('YYYY-MM-DD')}}]",
   create: true,
   format: "yml",
+  view_groups: [
+    {
+      label: "Show in past events",
+      field: "show_in_past_events",
+    },
+    {
+      label: "Location",
+      field: "location",
+    },
+  ],
   fields: [
     {
       name: "type",

--- a/workspaces/cms-data/src/events.ts
+++ b/workspaces/cms-data/src/events.ts
@@ -21,6 +21,7 @@ export interface Event {
     readonly link: string;
     readonly isExternal: boolean;
   };
+  readonly show_in_past_events?: boolean;
 }
 
 export async function getEvents(locale: string): Promise<readonly Event[]> {


### PR DESCRIPTION
# Helpful resources

[Task details](https://www.notion.so/yuki-labs/Events-Keep-remove-events-when-over-b9b936fe584f47649b1e0efce2a1ca23)

[Deployment Preview](https://starknet-website-git-events-past-events-yuki-labs.vercel.app/)

[CMS preview](https://82e300be.starknet-netlify-cms.pages.dev/#/)

# Changes
#### 1. Updated [events collection](https://82e300be.starknet-netlify-cms.pages.dev/#/collections/events) to have `show_in_past_events` flag

 ![Screen Shot 2023-05-05 at 10 06 46](https://user-images.githubusercontent.com/126797224/236381276-2ea79b5b-7afa-4a96-ba6f-cc13ea8cfde7.png)

#### 2.  Added `group by` to [events collection](https://82e300be.starknet-netlify-cms.pages.dev/#/collections/events) to enable users group events by  `show_in_past_events` flag and location

![Screen Shot 2023-05-05 at 10 13 07](https://user-images.githubusercontent.com/126797224/236381899-46a7fbc3-c90b-467b-afa2-7141597e4b2e.png)

![Screen Shot 2023-05-05 at 10 13 49](https://user-images.githubusercontent.com/126797224/236381942-b00d1b95-163f-4ec5-9dcc-516483c93212.png)

####  3. Updated [past events](https://starknet-website-git-events-past-events-yuki-labs.vercel.app/en/events/past) page to filter out events with `show_in_past_events: false` flag 

# Guide to test changes.

#### 1. Visit [Starknet London Meetup 3](https://82e300be.starknet-netlify-cms.pages.dev/#/collections/events/entries/starknet-london-meetup-3) entry and notice `show_in_past_events` flag is set to false

#### 2. Visit [past events page of PR](https://starknet-website-git-events-past-events-yuki-labs.vercel.app/en/events/past) and choose Europe location. And notice `Starknet London Meetup 3` is not shown in past events.

![Screen Shot 2023-05-05 at 10 07 58](https://user-images.githubusercontent.com/126797224/236381371-113d3662-1ac2-4d3f-8cf8-912e49782ee7.png)

#### 3. Visit  [past events page of Dev](https://starknet-website-git-dev-yuki-labs.vercel.app/en/events/past) and select Europe location. Notice `Starknet London Meetup 3` is shown in second. (Since these changes are not merged yet)

![Screen Shot 2023-05-05 at 10 09 27](https://user-images.githubusercontent.com/126797224/236381517-4e2bad9c-34a9-4f54-968a-b384058da108.png)
