### PR TITLE
randomize object orders in some pages

### DIFF
--- a/_data/pages/resources-and-tools.yml
+++ b/_data/pages/resources-and-tools.yml
@@ -11,6 +11,7 @@ blocks:
   - type: link_list
     heading: Libraries
     listSize: lg
+    randomize: true
     blocks:
       - type: link_list_item
         link:
@@ -45,6 +46,7 @@ blocks:
   - type: link_list
     heading: Development frameworks
     listSize: lg
+    randomize: true
     blocks:
       - link:
           custom_title: "Protostar "
@@ -67,6 +69,7 @@ blocks:
   - type: link_list
     heading: "Editor plugins "
     listSize: lg
+    randomize: true
     blocks:
       - type: link_list_item
         link:
@@ -89,6 +92,7 @@ blocks:
   - type: link_list
     heading: Templates
     listSize: lg
+    randomize: true
     blocks:
       - type: link_list_item
         link:
@@ -111,6 +115,7 @@ blocks:
   - type: link_list
     heading: "General "
     listSize: lg
+    randomize: true
     blocks:
       - type: link_list_item
         link:
@@ -185,6 +190,7 @@ blocks:
   - type: link_list
     heading: Full-nodes & API services
     listSize: lg
+    randomize: true
     blocks:
       - link:
           hasIcon: false

--- a/src/blocks/Block.tsx
+++ b/src/blocks/Block.tsx
@@ -12,7 +12,7 @@ import BlockBridges from "./dataBlocks/BlockBridges/BlockBridges";
 import BlockOnRamps from "./dataBlocks/BlockOnRamps/BlockOnRamps";
 import BlockWallets from "./dataBlocks/BlockWallets/BlockWallets";
 import { Container } from "./Container";
-import { LinkList, LinkListItem } from "./LinkList";
+import { LinkList } from "./LinkList";
 import { AccordionItem, AccordionRoot } from "./AccordionBlock";
 import { PageHeaderBlock } from "./PageHeaderBlock";
 import { OrderedBlock, OrderedBlockItem } from "./OrderedBlock";
@@ -80,18 +80,7 @@ Props): JSX.Element {
       </BlockCards>
     );
   } else if (block.type === "link_list") {
-    return (
-      <LinkList heading={block.heading} listSize={block.listSize}>
-        {block.blocks.map((item, i) => (
-          <LinkListItem
-            key={i}
-            link={item.link}
-            subLabel={item.subLabel}
-            avatar={item.avatar}
-          />
-        ))}
-      </LinkList>
-    );
+    return <LinkList {...block} />;
   } else if (block.type === "accordion") {
     return (
       <AccordionRoot heading={block.heading}>

--- a/src/blocks/LinkList.tsx
+++ b/src/blocks/LinkList.tsx
@@ -1,21 +1,17 @@
 "use client";
 import React from "react";
 import * as StarkLinkList from "@ui/LinkList/LinkList";
+import { LinkListBlock } from "workspaces/cms-data/src/pages";
+import { getShuffledArray } from "src/utils/getShuffledArray";
 
-type Props = {
-  children: React.ReactNode;
-  heading?: string;
-  listSize?: "sm" | "md" | "lg";
-};
+export const LinkList = ({ randomize, blocks, ...rest }: LinkListBlock) => {
+  const items = randomize ? getShuffledArray(blocks || []) : blocks;
 
-export const LinkList = (props: Props) => {
   return (
-    <StarkLinkList.Root heading={props.heading} listSize={props.listSize}>
-      {props.children}
+    <StarkLinkList.Root {...rest}>
+      {items.map((item, i) => (
+        <StarkLinkList.Item key={i} {...item} />
+      ))}
     </StarkLinkList.Root>
   );
-};
-
-export const LinkListItem = (props: StarkLinkList.ItemProps) => {
-  return <StarkLinkList.Item {...props} />;
 };

--- a/src/blocks/dataBlocks/BlockBlockExplorers/BlockBlockExplorers.tsx
+++ b/src/blocks/dataBlocks/BlockBlockExplorers/BlockBlockExplorers.tsx
@@ -10,18 +10,17 @@ export default function BlockBlockExplorers({
   noOfItems,
   blockExplorers = [],
 }: Props): JSX.Element {
+  const randomizedBlockExplorers = blockExplorers.slice(0, noOfItems);
   return (
     <Box>
       <Container maxW="1062px">
         <Flex gap={4} direction="column" flex={1}>
-          {blockExplorers.map((blockExplorer, i) => {
-            if (noOfItems && i <= noOfItems) return null;
+          {randomizedBlockExplorers.map((blockExplorer, i) => {
             return (
               <ListCard
                 href={blockExplorer.website_url}
                 twitterHandle={blockExplorer.twitter}
                 image={blockExplorer.image}
-                // startDateTime="Fri, Jan 12 • 2:00 PM EST"
                 key={blockExplorer.name}
                 description={blockExplorer.description}
                 title={blockExplorer.name}

--- a/src/blocks/dataBlocks/BlockBlockExplorers/BlockBlockExplorers.tsx
+++ b/src/blocks/dataBlocks/BlockBlockExplorers/BlockBlockExplorers.tsx
@@ -2,6 +2,7 @@
 import { Box, Flex, Container } from "src/libs/chakra-ui";
 import { ListCard } from "@ui/Card/ListCard";
 import { BlockExplorer } from "@starknet-io/cms-data/src/block-explorers";
+import { getShuffledArray } from "src/utils/getShuffledArray";
 interface Props extends LocaleProps {
   noOfItems?: number;
   readonly blockExplorers: readonly BlockExplorer[];
@@ -11,7 +12,10 @@ export default function BlockBlockExplorers({
   noOfItems,
   blockExplorers = [],
 }: Props): JSX.Element {
-  const randomizedBlockExplorers = blockExplorers.slice(0, noOfItems);
+  const randomizedBlockExplorers = getShuffledArray(blockExplorers).slice(
+    0,
+    noOfItems
+  );
   return (
     <Box>
       <Container maxW="1062px">

--- a/src/blocks/dataBlocks/BlockBlockExplorers/BlockBlockExplorers.tsx
+++ b/src/blocks/dataBlocks/BlockBlockExplorers/BlockBlockExplorers.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { Box, Flex, Container } from "src/libs/chakra-ui";
 import { ListCard } from "@ui/Card/ListCard";
 import { BlockExplorer } from "@starknet-io/cms-data/src/block-explorers";

--- a/src/blocks/dataBlocks/BlockBridges/BlockBridges.tsx
+++ b/src/blocks/dataBlocks/BlockBridges/BlockBridges.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { Box, Flex, Container } from "src/libs/chakra-ui";
 import { ListCard } from "@ui/Card/ListCard";
 import { Bridge } from "@starknet-io/cms-data/src/bridges";

--- a/src/blocks/dataBlocks/BlockBridges/BlockBridges.tsx
+++ b/src/blocks/dataBlocks/BlockBridges/BlockBridges.tsx
@@ -1,6 +1,7 @@
 import { Box, Flex, Container } from "src/libs/chakra-ui";
 import { ListCard } from "@ui/Card/ListCard";
 import { Bridge } from "@starknet-io/cms-data/src/bridges";
+import { getShuffledArray } from "src/utils/getShuffledArray";
 interface Props extends LocaleProps {
   noOfItems?: number;
   readonly bridges: readonly Bridge[];
@@ -10,12 +11,13 @@ export default function BlockBridges({
   noOfItems,
   bridges = [],
 }: Props): JSX.Element {
+  const randomizedBridges = getShuffledArray(bridges).slice(0, noOfItems);
+
   return (
     <Box>
       <Container maxW="1062px">
         <Flex gap={4} direction="column" flex={1}>
-          {bridges.map((bridge, i) => {
-            if (noOfItems && i <= noOfItems) return null;
+          {randomizedBridges.map((bridge, i) => {
             return (
               <ListCard
                 href={bridge.website_url}

--- a/src/blocks/dataBlocks/BlockDapps/BlockDapps.tsx
+++ b/src/blocks/dataBlocks/BlockDapps/BlockDapps.tsx
@@ -1,6 +1,7 @@
 import { Box, Flex, Container } from "src/libs/chakra-ui";
 import { ListCard } from "@ui/Card/ListCard";
 import { Dapp } from "@starknet-io/cms-data/src/dapps";
+import { getShuffledArray } from "src/utils/getShuffledArray";
 interface Props extends LocaleProps {
   noOfItems?: number;
   readonly dapps: readonly Dapp[];
@@ -8,15 +9,15 @@ interface Props extends LocaleProps {
 
 export default function BlockDapps({
   noOfItems,
-  // params: { locale },
   dapps = [],
 }: Props): JSX.Element {
+  const randomizedDapps = getShuffledArray(dapps).slice(0, noOfItems);
+
   return (
     <Box>
       <Container maxW="1062px">
         <Flex gap={4} direction="column" flex={1}>
-          {dapps.map((dapp, i) => {
-            if (noOfItems && i <= noOfItems) return null;
+          {randomizedDapps.map((dapp, i) => {
             return (
               <ListCard
                 href={dapp.website_url}

--- a/src/blocks/dataBlocks/BlockDapps/BlockDapps.tsx
+++ b/src/blocks/dataBlocks/BlockDapps/BlockDapps.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { Box, Flex, Container } from "src/libs/chakra-ui";
 import { ListCard } from "@ui/Card/ListCard";
 import { Dapp } from "@starknet-io/cms-data/src/dapps";

--- a/src/blocks/dataBlocks/BlockOnRamps/BlockOnRamps.tsx
+++ b/src/blocks/dataBlocks/BlockOnRamps/BlockOnRamps.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { Box, Flex, Container } from "src/libs/chakra-ui";
 import { ListCard } from "@ui/Card/ListCard";
 import { FiatOnRamp } from "@starknet-io/cms-data/src/fiat-on-ramps";

--- a/src/blocks/dataBlocks/BlockOnRamps/BlockOnRamps.tsx
+++ b/src/blocks/dataBlocks/BlockOnRamps/BlockOnRamps.tsx
@@ -1,6 +1,7 @@
 import { Box, Flex, Container } from "src/libs/chakra-ui";
 import { ListCard } from "@ui/Card/ListCard";
 import { FiatOnRamp } from "@starknet-io/cms-data/src/fiat-on-ramps";
+import { getShuffledArray } from "src/utils/getShuffledArray";
 interface Props extends LocaleProps {
   noOfItems?: number;
   readonly fiatOnRamps: readonly FiatOnRamp[];
@@ -8,15 +9,18 @@ interface Props extends LocaleProps {
 
 export default function BlockOnRamps({
   noOfItems,
-  params: { locale },
   fiatOnRamps = [],
 }: Props): JSX.Element {
+  const randomizedFiatOnRamps = getShuffledArray(fiatOnRamps).slice(
+    0,
+    noOfItems
+  );
+
   return (
     <Box>
       <Container maxW="1062px">
         <Flex gap={4} direction="column" flex={1}>
-          {fiatOnRamps.map((fiatOnRamp, i) => {
-            if (noOfItems && i <= noOfItems) return null;
+          {randomizedFiatOnRamps.map((fiatOnRamp, i) => {
             return (
               <ListCard
                 href={fiatOnRamp.website_url}

--- a/src/blocks/dataBlocks/BlockWallets/BlockWallets.tsx
+++ b/src/blocks/dataBlocks/BlockWallets/BlockWallets.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { Box, Flex, Container } from "src/libs/chakra-ui";
 import { ListCard } from "@ui/Card/ListCard";
 import { Wallet } from "@starknet-io/cms-data/src/wallets";

--- a/src/blocks/dataBlocks/BlockWallets/BlockWallets.tsx
+++ b/src/blocks/dataBlocks/BlockWallets/BlockWallets.tsx
@@ -1,6 +1,7 @@
 import { Box, Flex, Container } from "src/libs/chakra-ui";
 import { ListCard } from "@ui/Card/ListCard";
 import { Wallet } from "@starknet-io/cms-data/src/wallets";
+import { getShuffledArray } from "src/utils/getShuffledArray";
 interface Props extends LocaleProps {
   noOfItems?: number;
   readonly wallets: readonly Wallet[];
@@ -10,12 +11,15 @@ export default function BlockWallets({
   noOfItems,
   wallets = [],
 }: Props): JSX.Element {
+  const randomWallets = getShuffledArray(wallets).slice(0, noOfItems);
+  console.log("wallets", wallets);
+  console.log("randomWallets", randomWallets);
+
   return (
     <Box>
       <Container maxW="1062px">
         <Flex gap={4} direction="column" flex={1}>
-          {wallets.map((wallet, i) => {
-            if (noOfItems && i <= noOfItems) return null;
+          {randomWallets.map((wallet, i) => {
             return (
               <ListCard
                 href={wallet.website_url}

--- a/src/blocks/dataBlocks/BlockWallets/BlockWallets.tsx
+++ b/src/blocks/dataBlocks/BlockWallets/BlockWallets.tsx
@@ -13,8 +13,6 @@ export default function BlockWallets({
   wallets = [],
 }: Props): JSX.Element {
   const randomWallets = getShuffledArray(wallets).slice(0, noOfItems);
-  console.log("wallets", wallets);
-  console.log("randomWallets", randomWallets);
 
   return (
     <Box>

--- a/src/utils/getShuffledArray.ts
+++ b/src/utils/getShuffledArray.ts
@@ -1,6 +1,6 @@
 // https://stackoverflow.com/a/12646864
 
-export function getShuffledArray(_array: readonly any[]) {
+export function getShuffledArray<T>(_array: readonly T[]) {
   const array = _array.slice(0);
   for (let i = array.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));

--- a/src/utils/getShuffledArray.ts
+++ b/src/utils/getShuffledArray.ts
@@ -1,0 +1,11 @@
+// https://stackoverflow.com/a/12646864
+
+export function getShuffledArray(_array: readonly any[]) {
+  const array = _array.slice(0);
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+
+  return array;
+}

--- a/workspaces/cms-config/src/blocks.ts
+++ b/workspaces/cms-config/src/blocks.ts
@@ -427,6 +427,13 @@ export const blocks = [
         required: false,
       },
       {
+        name: "randomize",
+        label: "Randomize",
+        widget: "boolean",
+        required: false,
+        default: false,
+      },
+      {
         name: "blocks",
         label: "Blocks",
         widget: "list",

--- a/workspaces/cms-data/src/pages.ts
+++ b/workspaces/cms-data/src/pages.ts
@@ -121,6 +121,8 @@ export interface LinkListBlock {
   readonly type: "link_list";
   readonly heading?: string;
   readonly listSize?: "sm" | "md" | "lg";
+  readonly listGap?: "sm" | "md" | "lg";
+  randomize?: boolean;
   readonly blocks: readonly LinkListItem[];
 }
 export interface AccordionBlock {


### PR DESCRIPTION
Useful resources
- [Notion Link](https://www.notion.so/yuki-labs/Randomize-order-of-objects-AB-testing-8b7c73a05148419d96b34f4672e6e554)
- [Branch Preview](https://starknet-website-git-rendomize-objects-yuki-labs.vercel.app/)
- [CMS preview](https://d0917188.starknet-netlify-cms.pages.dev/)

Randomize object data in following pages:

- [Dapps](https://starknet-website-git-rendomize-objects-yuki-labs.vercel.app/en/ecosystem/dapps)
- [Wallets](https://starknet-website-git-rendomize-objects-yuki-labs.vercel.app/en/ecosystem/wallets)
- [Bridges and Onramps](https://starknet-website-git-rendomize-objects-yuki-labs.vercel.app/en/ecosystem/bridges-and-onramps)
- [Block Explorers](https://starknet-website-git-rendomize-objects-yuki-labs.vercel.app/en/ecosystem/block-explorers)

Randomize link list items in [Tools and resources](https://starknet-website-git-rendomize-objects-yuki-labs.vercel.app/en/developers/tools-and-resources) page by adding `randomize` field for [link lists](https://d0917188.starknet-netlify-cms.pages.dev/#/collections/pages/entries/resources-and-tools). 

<img width="652" alt="Screen Shot 2023-05-19 at 17 37 04" src="https://github.com/starknet-io/starknet-website/assets/126797224/205dc8ce-ad34-4d33-94a4-55f13d8f95ac">
