### PR TITLE
Change engineering category to developers && handle redirects

### DIFF
--- a/_data/categories/engineering.yml
+++ b/_data/categories/engineering.yml
@@ -1,2 +1,2 @@
 id: engineering
-name: Engineering
+name: Developers

--- a/_data/settings/redirects.yml
+++ b/_data/settings/redirects.yml
@@ -99,3 +99,5 @@ items:
     destination: "https://starknet.karmahq.xyz"
   - source: /governance
     destination: "https://starknet.karmahq.xyz"
+  - source: /:slug/posts/engineering/:path*
+    destination: /:slug/posts/developers/:path*

--- a/src/app/[locale]/posts/(components)/PostsPage.tsx
+++ b/src/app/[locale]/posts/(components)/PostsPage.tsx
@@ -385,17 +385,17 @@ function CustomHits({ categories, params }: Pick<Props, "categories" | "params">
         {filteredHits.map((hit, i) => {
           // todo: add a featured image once we have image templates in place
           const date = moment(hit.published_date).format("MMM DD, YYYY");
-          const category = categories.find((c) => c.id === hit.category)!;
+          const category = categories.find((c) => c.id === hit.category);
 
           return (
             <ArticleCard.Root
-              href={`/${hit.locale}/posts/${category.slug}/${hit.slug}`}
+              href={`/${hit.locale}/posts/${category?.slug}/${hit.slug}`}
               key={i}
             >
               <ArticleCard.Image url={hit.image} />
 
               <ArticleCard.Body>
-                <ArticleCard.Category category={category} />
+                {category && <ArticleCard.Category category={category} />}
                 <ArticleCard.Content
                   title={hit.title}
                   excerpt={hit.short_desc}

--- a/src/app/[locale]/posts/[category]/[slug]/page.tsx
+++ b/src/app/[locale]/posts/[category]/[slug]/page.tsx
@@ -32,12 +32,12 @@ export async function generateStaticParams() {
 
     for (const slug of files) {
       const post = await getPostBySlug(slug.replace(/\.json$/, ""), locale);
-      const category = categories.find((c) => c.id === post.category)!;
+      const category = categories.find((c) => c.id === post.category);
 
       params.push({
         locale,
         slug: post.slug,
-        category: category.slug,
+        category: category?.slug,
       });
     }
   }


### PR DESCRIPTION
- Updates engineering category to [developers](https://starknet-website-git-update-blog-category-yuki-labs.vercel.app/en/posts/developers)

<img width="1378" alt="Screen Shot 2023-06-09 at 12 02 17" src="https://github.com/starknet-io/starknet-website/assets/126797224/04e35bab-48cf-481f-8730-b2e2341152c0">


- Redirects [posts/engineering](https://starknet-website-git-update-blog-category-yuki-labs.vercel.app/en/posts/engineering/what-are-storage-proofs-and-how-can-they-improve-oracles) to [posts/developers](https://starknet-website-git-update-blog-category-yuki-labs.vercel.app/en/posts/developers/what-are-storage-proofs-and-how-can-they-improve-oracles)

- Redirects [posts/engineering/individual-blog](https://starknet-website-git-update-blog-category-yuki-labs.vercel.app/en/posts/engineering/what-are-storage-proofs-and-how-can-they-improve-oracles) to [posts/developers/individual-blog](https://starknet-website-git-update-blog-category-yuki-labs.vercel.app/en/posts/developers/what-are-storage-proofs-and-how-can-they-improve-oracles)