### PR TITLE
Show published date in posts summary && show_in_past_events defaults to false

### DIFF
--- a/workspaces/cms-config/src/collections/events.ts
+++ b/workspaces/cms-config/src/collections/events.ts
@@ -150,7 +150,7 @@ export const eventsCollectionConfig = {
       name: "show_in_past_events",
       label: "Show in Past Events (after it ends)",
       widget: "boolean",
-      default: true,
+      default: false,
       required: false,
     },
     {

--- a/workspaces/cms-config/src/collections/posts.ts
+++ b/workspaces/cms-config/src/collections/posts.ts
@@ -7,12 +7,12 @@ export const postsCollectionConfig = {
   label: "Blog - Posts",
   label_singular: "Post",
   identifier_field: "id",
-  folder: '_data/posts',
+  folder: "_data/posts",
   create: true,
   format: "yml",
   slug: "{{title}}",
   preview_path: "/preview/posts/{{id}}",
-  summary: "{{title}}",
+  summary: "{{title}} [{{published_date | date('YYYY-MM-DD')}}]",
   sortable_fields: ["published_date", "title"],
   fields: [
     {


### PR DESCRIPTION
Notion Links

1. [Display post published date in summary](https://www.notion.so/yuki-labs/Display-post-published-date-in-CMS-summary-baf763ffae494ae0b3f6038d7c981690)
2. [Set show_in_past_events to false by default](https://www.notion.so/yuki-labs/Set-save-to-past-events-switch-to-off-by-default-1a77c358571e4a31840992aaa08d8460)

CMS link: https://f7296dbd.starknet-netlify-cms.pages.dev/#/collections/posts

Things to test

1. Published date in [blog posts collection](https://f7296dbd.starknet-netlify-cms.pages.dev/#/collections/posts)
2. `Show in past events field` while [creating new event](https://f7296dbd.starknet-netlify-cms.pages.dev/#/collections/events/new)