### PR TITLE
Fix developers redirect

### DIFF
--- a/_data/settings/redirects.yml
+++ b/_data/settings/redirects.yml
@@ -99,5 +99,7 @@ items:
     destination: "https://starknet.karmahq.xyz"
   - source: /governance
     destination: "https://starknet.karmahq.xyz"
+  - source: /:slug/posts/engineering
+    destination: /en/posts/developers
   - source: /:slug/posts/engineering/:path*
-    destination: /:slug/posts/developers/:path*
+    destination: /en/posts/developers


### PR DESCRIPTION
I noticed redirecting works different in cloudflare. 

[/locale/posts/engineering](https://starknet-website-developers-redirect.yukilabs.workers.dev/en/posts/engineering) will be redirected to [/en/posts/developers](https://starknet-website-developers-redirect.yukilabs.workers.dev/en/posts/developers). 

And /locale/posts/engineering/postname/ will also be redirected to /en/posts/developers