### PR TITLE
Integrate hotjar to starknet website

### DIFF
--- a/workspaces/website/src/renderer/_default.page.server.tsx
+++ b/workspaces/website/src/renderer/_default.page.server.tsx
@@ -90,6 +90,17 @@ export async function render(pageContext: PageContextServer) {
 
         gtag('config', '${GOOGLE_TAG_ID}');
       </script>
+      <!-- Hotjar Tracking Code for Starknet -->
+      <script>
+          (function(h,o,t,j,a,r){
+              h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
+              h._hjSettings={hjid:3541762,hjsv:6};
+              a=o.getElementsByTagName('head')[0];
+              r=o.createElement('script');r.async=1;
+              r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
+              a.appendChild(r);
+          })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+      </script>
     </head>
     <body>
       <div id="page-view">${stream}</div>


### PR DESCRIPTION
Helpful links
- [Slack thread](https://yuki-5mg4807.slack.com/archives/C0478LW0RSQ/p1687265449432229)
- [Notion ticket](https://www.notion.so/yuki-labs/HotJar-Integration-Starknet-Hub-d434d4b3e6024c0a894c6551b099c068)

Validating that script is added properly.

1. Go to any page in [PR preview website](https://starknet-website-hotjar-integration.yukilabs.workers.dev/en)
2. Go to networks tab and filter by hotjar after reloading

<img width="461" alt="Screen Shot 2023-06-29 at 12 10 26" src="https://github.com/starknet-io/starknet-website/assets/126797224/c2715e3d-31e2-4386-ae29-78851c6ba7f8">
