### PR TITLE
Add starknet.dart in "resources-and-tools"

### DIFF
--- a/_data/pages/resources-and-tools.yml
+++ b/_data/pages/resources-and-tools.yml
@@ -43,6 +43,12 @@ blocks:
           custom_external_link: https://github.com/Starknet-php/starknet.php
         subLabel:
           label: "A PHP SDK for Starknet "
+      - type: link_list_item
+        link:
+          custom_title: starknet.dart
+          custom_external_link: https://github.com/focustree/starknet.dart
+        subLabel:
+          label: "A Dart/Flutter SDK for Starknet"
   - type: link_list
     heading: Development frameworks
     listSize: lg


### PR DESCRIPTION
Starknet.dart is a SDK which allow you to create mobile application using flutter framework or CLI one.

This framework is used by the focustree mobile application.
