### PR TITLE
Fix the closed summit popup overlaying links

### DIFF
--- a/workspaces/website/src/components/Layout/SummitPromo.tsx
+++ b/workspaces/website/src/components/Layout/SummitPromo.tsx
@@ -29,7 +29,8 @@ export const SummitPromo = () => {
         bottom:"16px",
         width:"336px",
         height:"358px",
-        zIndex: 999
+        zIndex: 999,
+        pointerEvents: isPopupOpen ? "auto" : "none",
     }}>
     <Box
         sx={{ 


### PR DESCRIPTION
I was not able to click on footer links on the right because the summit popup was overlaying it even when it is closed 