### PR TITLE
Fix twitter share image

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -50,10 +50,17 @@ jobs:
         with:
           slug-maxlength: 28
 
+      - name: Set VITE_SITE_URL
+        run: |
+          if [ "${{ env.GITHUB_REF_SLUG_URL }}" = "production" ]; then
+            echo "VITE_SITE_URL=https://www.starknet.io" >> $GITHUB_ENV
+          else
+            echo "VITE_SITE_URL=https://${{ env.GITHUB_REF_SLUG_URL }}.starknet-website.pages.dev" >> $GITHUB_ENV
+          fi
+
       - name: Build project
         run: yarn workspace @starknet-io/website build
         env:
-          VITE_SITE_URL: https://${{ env.GITHUB_REF_SLUG_URL }}.starknet-website.pages.dev
           VITE_ALGOLIA_INDEX: ${{ github.ref_name == 'production' && 'production' || 'dev' }}
           VITE_ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           VITE_ALGOLIA_SEARCH_API_KEY: ${{ secrets.ALGOLIA_SEARCH_API_KEY }}


### PR DESCRIPTION
This pr fixes the issue with images in twitter sharing. This seems to be a deeper issue with the `VITE_SITE_URL` env variable pointing to `production.starknet-website.pages.dev` instead of the actual domain url. This domain is not actually getting the images uploaded to it since June. but they are present in the main domain. Since the environment is part of the infrastructure and i had trouble pinpointing where to set it, this solution should work as a stopgap measure until we figure out the big picture.