### PR TITLE
Update events section for all events

### DIFF
--- a/workspaces/website/src/blocks/dataBlocks/BlockCommunityEvents/(components)/BlockCommunityEventsList.tsx
+++ b/workspaces/website/src/blocks/dataBlocks/BlockCommunityEvents/(components)/BlockCommunityEventsList.tsx
@@ -46,13 +46,13 @@ export function BlockCommunityEventsList({
         facetsRefinements={{ locale: [params.locale] }}
         filters={`start_date_ts > ${getUnixTime(
           startOfDay(new Date())
-        )} AND type: community_event`}
+        )}`}
       />
       <Container maxW="1062px">
         <Box>
           <Flex justifyContent="center">
             <Heading variant="h2" color="heading-navy-fg" mb="64px">
-              Community Events
+              Upcoming Events
             </Heading>
           </Flex>
           <CustomHits hitsPerPage={hitsPerPage} />


### PR DESCRIPTION
This pr update the events section on the homepage to not support only community events.

[Task](https://www.notion.so/untile/Homepage-Community-Events-is-empty-1aa81b849263410f91e1041c8de10a38?pvs=4).