### PR TITLE
Add type list to ListCard

### DIFF
--- a/workspaces/website/src/blocks/ListCardItems.tsx
+++ b/workspaces/website/src/blocks/ListCardItems.tsx
@@ -17,6 +17,10 @@ interface ListCardItems {
   website_url: string;
   twitter: string;
   image: string;
+  type_list: {
+    type: string;
+    url: string;
+  }[];
 }
 
 interface Props extends LocaleProps {
@@ -33,7 +37,6 @@ export default function ListCardItems({
   card_list_items
 }:
 Props): JSX.Element {
-
   return (
     <Box>
       <Container maxW="1062px">
@@ -49,6 +52,7 @@ Props): JSX.Element {
                 key={`${card.title}-${i}`}
                 description={card.description}
                 title={card.title}
+                type_list={card.type_list}
               />
             );
           })}


### PR DESCRIPTION
This pr allow for tags to be aded to cad lists from the cms as pr this [Task](https://www.notion.so/untile/Include-tags-in-api-section-db637823ba6d4c09bf811aee8374a221?pvs=4)