### PR TITLE
Update Footer.tsx

### DIFF
--- a/workspaces/website/src/pages/(components)/Footer.tsx
+++ b/workspaces/website/src/pages/(components)/Footer.tsx
@@ -82,6 +82,7 @@ export const Footer = ({ mainMenu, seo }: Props) => {
                             <FooterComponent.FooterLink
                               isExternal={item.custom_external_link != null}
                               href={href}
+                              target="_blank"
                               key={itemIndex}
                             >
                               {label}


### PR DESCRIPTION
I added an attribute target="_blank" to the social media links in the footer section. This opens the linked page in a new tab without replacing the current page. Opening a link in a new tab or window helps prevent interrupting the user's current flow. This can be useful to ensure that users can easily return to the original page without using the browser's "back" button If a link opens in the same tab, it might cause the user to navigate away from the current page, which may not be the desired behaviour in certain situations.