### PR TITLE
fix: Responsive Styles iPad

### DIFF
--- a/workspaces/website/src/components/Layout/Navbar/MenuItemWithDropdown.tsx
+++ b/workspaces/website/src/components/Layout/Navbar/MenuItemWithDropdown.tsx
@@ -30,7 +30,7 @@ export const MenuItemWithDropdown = ({ children, label }: Props) => (
             bg={isOpen ? "button-nav-hover-bg" : "button-nav-bg"}
             size="sm"
             pl="16px"
-            pr="8px"
+            pr={{ xl: "8px" }}
             height="40px"
             variant="link"
             borderRadius="4px"

--- a/workspaces/website/src/components/Layout/Navbar/NavLayout.tsx
+++ b/workspaces/website/src/components/Layout/Navbar/NavLayout.tsx
@@ -6,6 +6,7 @@ import {
   useColorMode,
   Box,
 } from "@chakra-ui/react";
+
 import { IconButton } from "@ui/IconButton";
 import { StarknetLogo } from "@ui/Logo/StarknetLogo";
 import {
@@ -48,9 +49,9 @@ export const NavLayout = (props: NavLayoutProps) => {
             <StarknetLogo />
           </a>
           <Box display={{ base: "none", lg: "block" }}>
-              <ButtonGroup variant="link" spacing="18px" sx={{ pl: "34px" }}>
-                {props.items}
-              </ButtonGroup>
+            <ButtonGroup variant="link" spacing={{ md: "12px", xl: "18px"}} sx={{ pl: { lg: "16px", xl: "34px" } }}>
+              {props.items}
+            </ButtonGroup>
           </Box>
         </HStack>
         <HStack spacing={6}>
@@ -87,7 +88,7 @@ export const NavLayout = (props: NavLayoutProps) => {
               icon={<Icon as={MenuIcon} fontSize="2xl" />}
               aria-label="Open Menu"
               onClick={onClickMenu}
-              marginInlineStart="12px !important"
+              ml={{ xl: "12px !important" }}
             /></Box>
         </HStack>
       </HStack>

--- a/workspaces/website/src/pages/(components)/Footer.tsx
+++ b/workspaces/website/src/pages/(components)/Footer.tsx
@@ -34,7 +34,7 @@ export const Footer = ({ mainMenu, seo }: Props) => {
           />
         }
         align="stretch"
-        gap={10}
+        gap={{base: 10, md: 2, xl: 10}}
         alignItems="flex-start"
         justifyContent="flex-start"
         direction={{ base: "column", md: "row" }}

--- a/workspaces/website/src/pages/(components)/MainSearch.tsx
+++ b/workspaces/website/src/pages/(components)/MainSearch.tsx
@@ -312,7 +312,7 @@ export function MainSearch({ env, seo }: Props): JSX.Element | null {
         cursor="pointer"
         onClick={() => searchBox?.click()}
         pointerEvents="none"
-        display={{ base: "none", lg: "block" }}
+        display={{ base: "none", xl: "block" }}
       >
         /
       </Kbd>

--- a/workspaces/website/src/style/algolia/overrides.css
+++ b/workspaces/website/src/style/algolia/overrides.css
@@ -346,3 +346,13 @@ body.chakra-ui-dark .aa-Item[aria-selected=true] svg{
     background-color: transparent;
   }
 }
+@media screen and (min-width: 992px) and (max-width: 1280px) {
+  .aa-DetachedSearchButton {
+    min-width: 40px;
+    width: 40px;
+  }
+  .aa-DetachedSearchButtonPlaceholder{
+    display: none;
+  }
+}
+


### PR DESCRIPTION
Currently, the website lacks adaptation for iPad devices, causing the header and footer to extend beyond the screen.

## Current
<img width="443" alt="image" src="https://github.com/starknet-io/starknet-website/assets/65277457/ea64b363-c47a-4ac6-9813-edc16b9b7200">

## After
<img width="438" alt="image" src="https://github.com/starknet-io/starknet-website/assets/65277457/b3302905-b2a6-4afb-97dd-617c5bb9dba6">