### PR TITLE
Adjust footer style

### DIFF
--- a/workspaces/website/src/components/Footer/Footer.tsx
+++ b/workspaces/website/src/components/Footer/Footer.tsx
@@ -190,7 +190,8 @@ const FooterLink = ({ children, href, isExternal }: FooterLinkProps) => {
     <Link
       fontSize="sm"
       px="0"
-      height="36px"
+      py="6px"
+      lineHeight="24px"
       bg="navbar-link-bg"
       color={useColorModeValue("footer-link-fg", "footer-link-fg")}
       borderRadius={18}


### PR DESCRIPTION
Currently, the layout of the footer links becomes very crowded when in multiple lines; optimize this layout.

## Current
<img width="1521" alt="image" src="https://github.com/starknet-io/starknet-website/assets/65277457/a08337e9-1047-41a4-8165-85d38b6f9fe2">

## After 
<img width="1393" alt="image" src="https://github.com/starknet-io/starknet-website/assets/65277457/e19eda19-0c0d-4c90-8775-fdf87970aba3">
