### PR TITLE
Remove 'Learn' page

### DIFF
--- a/_data/pages/learn.yml
+++ b/_data/pages/learn.yml
@@ -1,30 +1,7 @@
 id: /learn/
 title: Learn
 template: landing
+hidden_page: true
 breadcrumbs: true
 page_last_updated: false
-blocks:
-  - type: hero
-    variant: learn
-    title: "Learn "
-    description: An educational guide to Starknet, how it works and how to start using it.
-  - type: group
-    blocks:
-      - size: large
-        color: orange
-        variant: image_icon_link_card
-        orientation: left
-        withIllustration: false
-        title: Starknet 101
-        icon: /assets/hero-1-.svg
-        type: image_icon_link_card
-        link:
-          custom_internal_link: /learn/
-          custom_title: Learn
-        description: Starknet is a layer-2 network that uses math and cryptography to
-          securely scale Ethereum. It is known as a Validity-rollup (or
-          ZK-rollup); it ”rolls” many transactions up to send to Ethereum as a
-          single transaction. Read on to learn the fundamentals.
-        columns: "4"
-  - type: markdown
-    body: Learn!
+blocks: []

--- a/workspaces/cms-config/src/collections/pages.ts
+++ b/workspaces/cms-config/src/collections/pages.ts
@@ -86,6 +86,12 @@ export const pagesCollectionConfig = {
       display_fields: ["title"],
     },
     {
+      name: "hidden_page",
+      label: "Omit page from navigation",
+      widget: "boolean",
+      default: false,
+    },
+    {
       name: "breadcrumbs",
       label: "Show breadcrumbs",
       widget: "boolean",

--- a/workspaces/cms-data/src/pages.ts
+++ b/workspaces/cms-data/src/pages.ts
@@ -221,6 +221,7 @@ export interface Page extends Meta {
   readonly toc?: boolean;
   readonly template: "landing" | "content" | "narrow content";
   readonly tocCustomTitle?: string;
+  readonly hidden_page: boolean;
   readonly breadcrumbs: boolean;
   readonly breadcrumbs_data?: readonly Omit<Page, "blocks">[];
   readonly pageLastUpdated: boolean;

--- a/workspaces/website/src/pages/(components)/CMSPage.tsx
+++ b/workspaces/website/src/pages/(components)/CMSPage.tsx
@@ -14,6 +14,7 @@ import {
 } from "@chakra-ui/react";
 import '@ui/CodeHighlight/code-highlight-init'
 import { blocksToTOC } from "./TableOfContents/blocksToTOC";
+import NotFound from "@ui/NotFound/NotFound";
 
 type CMSPageProps = {
   data: PageType;
@@ -28,6 +29,11 @@ export default function CMSPage({
   locale,
 }: CMSPageProps) {
   const date = data?.gitlog?.date;
+
+  if (data?.hidden_page) {
+    return <NotFound type="page" />;
+  }
+
   return (
     <Box>
       <PageLayout


### PR DESCRIPTION
[Task](https://www.notion.so/untile/Remove-page-64535741be864928a6cea5864d7df9bf?pvs=4)

A new page field `hidden_page` was added for pages that should not be published but have children (i.e. `/learn` must be removed but not `/learn/what-is-starknet`