### PR TITLE
Add sitemap to robots

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
+Sitemap: https://www.starknet.io/sitemap.xml
 User-agent: *
 Allow: /
 Disallow: /ar/*


### PR DESCRIPTION
This PR adds the sitemap location to robots.txt.

[Notion](https://www.notion.so/untile/Add-robots-txt-to-sitemap-SEO-0c13319156774412931c6173e9d6d7fe?pvs=4)