### PR TITLE
fixed issue  Socials #2281   fix-missing-target-blank-in-footer

### DIFF
--- a/workspaces/website/src/components/Footer/Footer.tsx
+++ b/workspaces/website/src/components/Footer/Footer.tsx
@@ -162,6 +162,7 @@ const Root = ({ children, seo, ...rest }: RootProps) => {
                     aria-label="Discord"
                     icon={<SiDiscord fontSize="1.25rem" />}
                     size="small"
+                    target="_blank"
                     marginRight="16px"
                   />
                   <IconButton
@@ -170,6 +171,7 @@ const Root = ({ children, seo, ...rest }: RootProps) => {
                     aria-label="GitHub"
                     icon={<SiGithub fontSize="1.25rem" />}
                     size="small"
+                    target="_blank"
                     marginRight="16px"
                   />
                   <IconButton
@@ -178,6 +180,7 @@ const Root = ({ children, seo, ...rest }: RootProps) => {
                     aria-label="YouTube"
                     icon={<SiYoutube fontSize="1.25rem" />}
                     size="small"
+                    target="_blank"
                     marginRight="16px"
                   />
                   <IconButton
@@ -185,6 +188,7 @@ const Root = ({ children, seo, ...rest }: RootProps) => {
                     href="https://twitter.com/Starknet"
                     aria-label="Twitter"
                     icon={<SiTwitter fontSize="1.25rem" />}
+                    target="_blank"
                     size="small"
                   />
                 </ButtonGroup>

--- a/workspaces/website/src/components/IconButton/IconButton.tsx
+++ b/workspaces/website/src/components/IconButton/IconButton.tsx
@@ -8,14 +8,16 @@ export interface Props extends IconButtonProps {
   href?: string;
   size?: | "default" | "small";
   variant?: 'outline' | 'primary';
+  target?: "_blank";
 };
 
-export const IconButton = forwardRef<HTMLButtonElement, Props>(({ 
-  href, 
-  toId, 
+export const IconButton = forwardRef<HTMLButtonElement, Props>(({
+  href,
+  toId,
   size,
   variant = 'primary' as keyof typeof iconButtonTheme.variants,
-  ...rest 
+  target,
+  ...rest
 }, ref) => {
   const paddingValue = size === "small" ? "0" : "11px";
   const minWidthValue = size === "small" ? "auto" : "2.5rem";
@@ -33,6 +35,7 @@ export const IconButton = forwardRef<HTMLButtonElement, Props>(({
       onClick={handleOnClick}
       padding={paddingValue}
       minWidth={minWidthValue}
+      target={target}
       sx={iconButtonTheme?.variants?.[variant]}
       {...rest}
     />


### PR DESCRIPTION
 Socials #2281 
fix-missing-target-blank-in-footer

Add new props target and  target="_bank" to IconButton

<img width="263" alt="grafik" src="https://github.com/starknet-io/starknet-website/assets/14287880/da4fb763-9668-475a-ac3e-e3fbb24290bf">
